### PR TITLE
Correctly resolve abstract non-virtual properties

### DIFF
--- a/source/Vega.USiteBuilder/ContentHelper.cs
+++ b/source/Vega.USiteBuilder/ContentHelper.cs
@@ -510,7 +510,7 @@ namespace Vega.USiteBuilder
             foreach (PropertyInfo propInfo in typeDocType.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
             {
                 DocumentTypePropertyAttribute propAttr = Util.GetAttribute<DocumentTypePropertyAttribute>(propInfo);
-                if (propAttr == null || (propInfo.GetGetMethod() != null && propInfo.GetGetMethod().IsVirtual))
+                if (propAttr == null || (propInfo.GetGetMethod() != null && propInfo.GetGetMethod().IsVirtual && !propInfo.GetGetMethod().IsFinal))
                 {
                     continue; // skip this property - not part of a Document Type or is virtual in which case value will be intercepted
                 }


### PR DESCRIPTION
Usitebuilder was incorrectly ignoring properties from an abstract base class that were finalised. This fix forces the contenthelper to check if the property is final.
