### PR TITLE
DocumentTypeManager Dictionary bug.

### DIFF
--- a/source/Vega.USiteBuilder/DocumentTypeBuilder/DocumentTypeManager.cs
+++ b/source/Vega.USiteBuilder/DocumentTypeBuilder/DocumentTypeManager.cs
@@ -242,7 +242,17 @@ namespace Vega.USiteBuilder
             foreach (Type typeDocType in Util.GetFirstLevelSubTypes(baseTypeDocType))
             {
                 string docTypeAlias = GetDocumentTypeAlias(typeDocType);
-                DocumentTypes.Add(docTypeAlias, typeDocType);
+
+                // Prevent "An item with the same key has already been added."
+                if (DocumentTypes.ContainsKey(docTypeAlias))
+                {
+                    // Reassign the value.
+                    DocumentTypes[docTypeAlias] = typeDocType;
+                }
+                else
+                {
+                    DocumentTypes.Add(docTypeAlias, typeDocType);
+                }
 
                 // create all children document types
                 FillDocumentTypes(typeDocType);


### PR DESCRIPTION
Fixing "An item with the same key has already been added." bug in
DocumentTypeManager.

The same bug may be present in other managers but I don't have the
opportunity just now to look at those.
